### PR TITLE
[FE] FEAT: 토스트 컴포넌트 및 useToaster 훅 추가

### DIFF
--- a/frontend/src/components/Board/BoardTemplate.tsx
+++ b/frontend/src/components/Board/BoardTemplate.tsx
@@ -205,6 +205,7 @@ const BoardContentContainerStyled = styled.div`
   margin-top: 1.5%;
   margin-left: 5%;
   margin-right: 5%;
+  margin-bottom: 1%;
   font-size: 13px;
 `;
 

--- a/frontend/src/components/OptionButton.tsx
+++ b/frontend/src/components/OptionButton.tsx
@@ -30,7 +30,7 @@ const OptionButton: React.FC<IOptionButtonProps> = ({
   memberId,
   memberName,
 }) => {
-  const [isToggled, setIsToggled] = useState(false);
+  const [isToggled, setIsToggled] = useState<boolean>(false);
   const setBanUserInfo = useSetRecoilState<IBanUserInfo>(banUserInfoState);
   const setCurrentBoardId = useSetRecoilState<number | null>(
     currentBoardIdState

--- a/frontend/src/components/modals/DeleteModal/DeleteModal.tsx
+++ b/frontend/src/components/modals/DeleteModal/DeleteModal.tsx
@@ -9,6 +9,7 @@ import {
   currentCommentIdState,
 } from "../../../recoil/atom";
 import useModal from "../../../hooks/useModal";
+import useToaster from "../../../hooks/useToaster";
 
 const DeleteModal = () => {
   const [currentOpenModal] = useRecoilState<ICurrentModalStateInfo>(
@@ -19,9 +20,11 @@ const DeleteModal = () => {
     currentCommentIdState
   );
   const { closeModal } = useModal();
+  const { popToast } = useToaster();
 
   const handleDelete = () => {
     closeModal(ModalType.DELETE);
+    popToast("해당 글이 삭제되었습니다.");
   };
 
   return (

--- a/frontend/src/components/modals/ModalLayout.tsx
+++ b/frontend/src/components/modals/ModalLayout.tsx
@@ -60,7 +60,8 @@ const ModalOverlay = styled.div`
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0.5);
-  animation: ${fadeIn} 0.2s ease-in-out;
+  animation: ${fadeIn} 0.2s;
+  backdrop-filter: blur(5px);
 `;
 
 const ModalContainer = styled.div`
@@ -69,7 +70,7 @@ const ModalContainer = styled.div`
   align-items: center;
   border-radius: 15px;
   box-shadow: var(--modal-shadow);
-  animation: ${fadeIn} 0.2s ease-in-out;
+  animation: ${fadeIn} 0.2s;
 `;
 
 export default ModalLayout;

--- a/frontend/src/components/toast/Toaster.tsx
+++ b/frontend/src/components/toast/Toaster.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from "react";
+import styled, { keyframes } from "styled-components";
+import { toastMessagesState } from "../../recoil/atom";
+import { useRecoilState, useResetRecoilState } from "recoil";
+import { IToastInfo } from "../../types/interface/toast.interface";
+
+const Toast: React.FC = () => {
+  const [toastMessages, setToastMessages] =
+    useRecoilState<IToastInfo[]>(toastMessagesState);
+  const resetToastMessage = useResetRecoilState(toastMessagesState);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      closeAllToasts();
+    }, 3000);
+    return () => clearTimeout(timer);
+  }, [toastMessages]);
+
+  const closeAllToasts = () => {
+    const updatedToasts = toastMessages.map((toast) => ({
+      ...toast,
+      isPopped: false,
+    }));
+    setToastMessages(updatedToasts);
+    setTimeout(() => {
+      resetToastMessage();
+    }, 200);
+  };
+
+  return (
+    <>
+      {toastMessages.map((toast, index) => (
+        <ToastWrapperStyled
+          key={index}
+          $index={index}
+          $isToastPopped={toast.isPopped}
+          onClick={closeAllToasts}
+        >
+          <p>{toast.text}</p>
+        </ToastWrapperStyled>
+      ))}
+    </>
+  );
+};
+
+const slideIn = keyframes`
+  from {
+    transform: translateX(100%);
+  }
+  to {
+    transform: translateX(0);
+  }
+`;
+
+const slideOut = keyframes`
+  from {
+    transform: translateX(0);
+  }
+  to {
+    transform: translateX(100%);
+  }
+`;
+
+const ToastWrapperStyled = styled.div<{
+  $index: number;
+  $isToastPopped: boolean;
+}>`
+  position: fixed;
+  top: ${({ $index }) => 60 * $index + 20}px;
+  right: 20px;
+  background-color: var(--white);
+  color: var(--lightgrey);
+  padding: 5px 20px;
+  border-radius: 4px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.2);
+  z-index: 9999;
+  transition: opacity 0.3s ease-in-out;
+  opacity: ${(props) => (props.$isToastPopped ? 1 : 0)};
+  pointer-events: ${(props) => (props.$isToastPopped ? "auto" : "none")};
+  animation: ${(props) => (props.$isToastPopped ? slideIn : slideOut)} 0.3s
+    forwards;
+`;
+
+export default Toast;

--- a/frontend/src/components/toast/Toaster.tsx
+++ b/frontend/src/components/toast/Toaster.tsx
@@ -16,12 +16,12 @@ const Toast: React.FC = () => {
     return () => clearTimeout(timer);
   }, [toastMessages]);
 
-  const closeAllToasts = () => {
+  const closeAllToasts = async () => {
     const updatedToasts = toastMessages.map((toast) => ({
       ...toast,
       isPopped: false,
     }));
-    setToastMessages(updatedToasts);
+    await setToastMessages(updatedToasts);
     setTimeout(() => {
       resetToastMessage();
     }, 200);

--- a/frontend/src/hooks/useToaster.tsx
+++ b/frontend/src/hooks/useToaster.tsx
@@ -1,0 +1,16 @@
+import { useSetRecoilState } from "recoil";
+import { toastMessagesState } from "../recoil/atom";
+import { IToastInfo } from "../types/interface/toast.interface";
+
+const useToaster = () => {
+  const setToastMessages = useSetRecoilState<IToastInfo[]>(toastMessagesState);
+
+  const popToast = (text: string) => {
+    const newToast: IToastInfo = { isPopped: true, text: text };
+    setToastMessages((previous) => [...previous, newToast]);
+  };
+
+  return { popToast };
+};
+
+export default useToaster;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -39,3 +39,7 @@ body {
   );
   background-repeat: no-repeat;
 }
+
+button {
+  cursor: pointer;
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -5,9 +5,9 @@ import App from "./App";
 import "./index.css";
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
-  // <React.StrictMode>
-  <RecoilRoot>
-    <App />
-  </RecoilRoot>
-  // {/* </React.StrictMode> */}
+  <React.StrictMode>
+    <RecoilRoot>
+      <App />
+    </RecoilRoot>
+  </React.StrictMode>
 );

--- a/frontend/src/pages/Layout.tsx
+++ b/frontend/src/pages/Layout.tsx
@@ -1,17 +1,18 @@
 import { Outlet, useLocation } from "react-router-dom";
+import { useRecoilState } from "recoil";
 import styled from "styled-components";
+import { isRightSectionOpenedState } from "../recoil/atom";
 import LeftMenuSection from "../components/LeftMenuSection";
 import RightSection from "../components/RightSection/RightSection";
 import BoardSortToggle from "../components/BoardSortToggle";
 import ModalContainer from "../components/modals/ModalContainer";
-import { isRightSectionOpenedState } from "../recoil/atom";
-import { useRecoilState } from "recoil";
+import Toaster from "../components/toast/Toaster";
 
 const Layout = () => {
   const location = useLocation();
   const [isRightSectionOpened] = useRecoilState<boolean>(
     isRightSectionOpenedState
-  ); // Initialize isRightSectionOpened state with false
+  );
 
   /**메인 화면일 때만 게시글 정렬 버튼 보여주기*/
   const isMainPage: boolean = location.pathname === "/";
@@ -36,6 +37,7 @@ const Layout = () => {
         </RightSectionContainer>
       </MainAreaWrapperStyled>
       <ModalContainer />
+      <Toaster />
     </WrapperStyled>
   );
 };

--- a/frontend/src/recoil/atom.ts
+++ b/frontend/src/recoil/atom.ts
@@ -4,6 +4,7 @@ import { ICurrentModalStateInfo } from "../types/interface/modal.interface";
 import { BoardsInfoDTO, CommentInfoDTO } from "../types/dto/board.dto";
 import { BoardCategory } from "../types/enum/board.category.enum";
 import { IBanUserInfo } from "../types/interface/user.interface";
+import { IToastInfo } from "../types/interface/toast.interface";
 
 /**현재까지 불러온 기본 정렬 게시물 목록*/
 export const defaultBoardsState = atom<BoardsInfoDTO>({
@@ -74,6 +75,11 @@ export const currentOpenModalState = atom<ICurrentModalStateInfo>({
     deleteModal: false,
     profileCardModal: false,
   },
+});
+
+export const toastMessagesState = atom<IToastInfo[]>({
+  key: "toastMessages",
+  default: [],
 });
 
 /**현재 밴할 대상인 유저 */

--- a/frontend/src/types/interface/toast.interface.ts
+++ b/frontend/src/types/interface/toast.interface.ts
@@ -1,0 +1,8 @@
+/**
+ * @isPopped 토스트 메시지가 열렸는지에 대한 boolean
+ * @text 토스트 메시지 내용
+ */
+export interface IToastInfo {
+  isPopped: boolean;
+  text: string;
+}


### PR DESCRIPTION
<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
> 앞으로 사용하게 될 토스트 컴포넌트 및 useToaster 훅을 추가했습니다. useToaster 훅의 popToast 함수의 인자로 문자열을 전달하면 해당 문자열을 메시지로 띄워주는 토스트 메시지가 토스터에 추가되게 됩니다.

> 토스터는 토스트 메시지들을 배열로 저장함으로써 다중 토스트 메시지를 지원합니다. 3초 경과 혹은 온클릭 이벤트가 발생했을 때 열려있는 토스트 메시지들은 일괄적으로 닫히게 됩니다. 아래는 예시의 사진입니다.

<img width="771" alt="스크린샷 2023-08-01 오후 1 36 47" src="https://github.com/42pet/42pet/assets/101867295/837a946f-d785-47ea-9bd6-5e5b5a0ae5b1">


https://github.com/42pet/42pet/issues/14
