### PR TITLE
[BE] 추상 클래스로 Entity 단순화 및 불변식, 도메인 검증, 익셉션 핸들링 구현

### DIFF
--- a/backend/src/main/java/proj/pet/block/domain/Block.java
+++ b/backend/src/main/java/proj/pet/block/domain/Block.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
 import proj.pet.utils.domain.MemberCompositeKey;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Table(name = "BLOCK")
 @Getter
-public class Block {
+public class Block implements Validatable {
 
 	@EmbeddedId
 	private MemberCompositeKey id;
@@ -29,4 +31,25 @@ public class Block {
 
 	@Column(name = "blocked_at", nullable = false)
 	private LocalDateTime blockedAt;
+
+	private Block(Member from, Member to, LocalDateTime now) {
+		this.id = MemberCompositeKey.of(from.getId(), to.getId());
+		this.from = from;
+		this.to = to;
+		this.blockedAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Block of(Member from, Member to, LocalDateTime now) {
+		return new Block(from, to, now);
+	}
+
+	@Override public boolean isValid() {
+		return id.isValid()
+				&& from != null
+				&& !from.isNew()
+				&& to != null
+				&& !to.isNew()
+				&& blockedAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/board/domain/Board.java
+++ b/backend/src/main/java/proj/pet/board/domain/Board.java
@@ -4,28 +4,27 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "BOARD")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Board {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Board extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "member_id", nullable = false, updatable = false)
 	private Member member;
 
 	@Column(name = "visible_scope", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private VisibleScope visibleScope;
 
 	/**
@@ -42,4 +41,25 @@ public class Board {
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
+	protected Board(Member member, VisibleScope visibleScope, String content, LocalDateTime now) {
+		this.member = member;
+		this.visibleScope = visibleScope;
+		this.content = content;
+		this.updatedAt = now;
+		this.createdAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Board of(Member member, VisibleScope visibleScope, String content, LocalDateTime now) {
+		return new Board(member, visibleScope, content, now);
+	}
+
+	@Override public boolean isValid() {
+		return this.member != null
+			&& !this.member.isNew()
+			&& this.visibleScope != null
+			&& this.content != null
+			&& this.updatedAt != null
+			&& this.createdAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/board/domain/Board.java
+++ b/backend/src/main/java/proj/pet/board/domain/Board.java
@@ -4,11 +4,17 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
+<<<<<<< Updated upstream
 import proj.pet.utils.domain.IdDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
+=======
+import proj.pet.reaction.domain.Reaction;
+>>>>>>> Stashed changes
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -62,4 +68,10 @@ public class Board extends IdDomain implements Validatable {
 			&& this.updatedAt != null
 			&& this.createdAt != null;
 	}
+
+	@OneToMany(mappedBy = "board",
+			targetEntity = Reaction.class,
+			cascade = CascadeType.ALL,
+			orphanRemoval = true)
+	private List<Reaction> reactions = new ArrayList<>();
 }

--- a/backend/src/main/java/proj/pet/board/domain/Board.java
+++ b/backend/src/main/java/proj/pet/board/domain/Board.java
@@ -4,13 +4,10 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
-<<<<<<< Updated upstream
+import proj.pet.reaction.domain.Reaction;
 import proj.pet.utils.domain.IdDomain;
 import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
-=======
-import proj.pet.reaction.domain.Reaction;
->>>>>>> Stashed changes
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -47,6 +44,12 @@ public class Board extends IdDomain implements Validatable {
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
+	@OneToMany(mappedBy = "board",
+			targetEntity = Reaction.class,
+			cascade = CascadeType.ALL,
+			orphanRemoval = true)
+	private List<Reaction> reactions = new ArrayList<>();
+
 	protected Board(Member member, VisibleScope visibleScope, String content, LocalDateTime now) {
 		this.member = member;
 		this.visibleScope = visibleScope;
@@ -68,10 +71,4 @@ public class Board extends IdDomain implements Validatable {
 			&& this.updatedAt != null
 			&& this.createdAt != null;
 	}
-
-	@OneToMany(mappedBy = "board",
-			targetEntity = Reaction.class,
-			cascade = CascadeType.ALL,
-			orphanRemoval = true)
-	private List<Reaction> reactions = new ArrayList<>();
 }

--- a/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
+++ b/backend/src/main/java/proj/pet/board/domain/BoardMedia.java
@@ -3,19 +3,17 @@ package proj.pet.board.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "board_media")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class BoardMedia {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class BoardMedia extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "board_id", nullable = false, updatable = false)
@@ -28,5 +26,26 @@ public class BoardMedia {
 	private Integer index;
 
 	@Column(name = "media_type", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private MediaType mediaType;
+
+	private BoardMedia(Board board, String mediaUrl, Integer index, MediaType mediaType) {
+		this.board = board;
+		this.mediaUrl = mediaUrl;
+		this.index = index;
+		this.mediaType = mediaType;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static BoardMedia of(Board board, String mediaUrl, Integer index, MediaType mediaType) {
+		return new BoardMedia(board, mediaUrl, index, mediaType);
+	}
+
+	@Override public boolean isValid() {
+		return board != null
+				&& !board.isNew()
+				&& mediaUrl != null
+				&& index != null
+				&& mediaType != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/category/domain/AnimalCategory.java
+++ b/backend/src/main/java/proj/pet/category/domain/AnimalCategory.java
@@ -3,30 +3,35 @@ package proj.pet.category.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
-import java.util.List;
-
-import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "animal_category")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class AnimalCategory {
+public class AnimalCategory extends IdDomain implements Validatable {
 
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+	private final static int MAX_NAME_LENGTH = 30;
 
-	@Column(name = "species", nullable = false, length = 30)
-	private String species;
+	@Column(name = "species", nullable = false, length = MAX_NAME_LENGTH)
+	@Enumerated(EnumType.STRING)
+	private Species species;
 
-	@OneToMany(mappedBy = "animalCategory", fetch = LAZY)
-	private List<MemberCategoryFilter> memberCategoryFilterList;
+	private AnimalCategory(Species species) {
+		this.species = species;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
 
-	@OneToMany(mappedBy = "animalCategory", fetch = LAZY)
-	private List<BoardCategoryFilter> boardCategoryFilterList;
+	public static AnimalCategory of(Species species) {
+		return new AnimalCategory(species);
+	}
 
+	@Override public boolean isValid() {
+		return species != null
+				&& species.name().length() <= MAX_NAME_LENGTH;
+	}
 }

--- a/backend/src/main/java/proj/pet/category/domain/BoardCategoryFilter.java
+++ b/backend/src/main/java/proj/pet/category/domain/BoardCategoryFilter.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.utils.domain.ConsumptionCompositeKey;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -13,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Table(name = "board_category_filter")
 @Getter
-public class BoardCategoryFilter {
+public class BoardCategoryFilter implements Validatable {
 
 	@EmbeddedId
 	private ConsumptionCompositeKey key;
@@ -27,4 +29,21 @@ public class BoardCategoryFilter {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "provider_id", nullable = false, updatable = false)
 	private AnimalCategory animalCategory;
+
+	private BoardCategoryFilter(Board board, AnimalCategory animalCategory) {
+		this.key = ConsumptionCompositeKey.of(board.getId(), animalCategory.getId());
+		this.board = board;
+		this.animalCategory = animalCategory;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static BoardCategoryFilter of(Board board, AnimalCategory animalCategory) {
+		return new BoardCategoryFilter(board, animalCategory);
+	}
+	@Override public boolean isValid() {
+		return board != null
+				&& !board.isNew()
+				&& animalCategory != null
+				&& !animalCategory.isNew();
+	}
 }

--- a/backend/src/main/java/proj/pet/category/domain/MemberCategoryFilter.java
+++ b/backend/src/main/java/proj/pet/category/domain/MemberCategoryFilter.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
 import proj.pet.utils.domain.ConsumptionCompositeKey;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.PROTECTED;
@@ -13,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Table(name = "member_category_filter")
 @Getter
 @Entity
-public class MemberCategoryFilter {
+public class MemberCategoryFilter implements Validatable {
 	@EmbeddedId
 	private ConsumptionCompositeKey key;
 
@@ -26,4 +28,22 @@ public class MemberCategoryFilter {
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "provider_id", nullable = false, updatable = false)
 	private AnimalCategory animalCategory;
+
+	private MemberCategoryFilter(Member member, AnimalCategory animalCategory) {
+		this.key = ConsumptionCompositeKey.of(member.getId(), animalCategory.getId());
+		this.member = member;
+		this.animalCategory = animalCategory;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static MemberCategoryFilter of(Member member, AnimalCategory animalCategory) {
+		return new MemberCategoryFilter(member, animalCategory);
+	}
+
+	@Override public boolean isValid() {
+		return member != null
+				&& !member.isNew()
+				&& animalCategory != null
+				&& !animalCategory.isNew();
+	}
 }

--- a/backend/src/main/java/proj/pet/category/domain/Species.java
+++ b/backend/src/main/java/proj/pet/category/domain/Species.java
@@ -1,0 +1,14 @@
+package proj.pet.category.domain;
+
+public enum Species {
+	DOG,
+	CAT,
+	FISH,
+	BIRD,
+	SMALL_ANIMAL,
+	REPTILE,
+	AMPHIBIAN,
+	INSECT,
+
+	;
+}

--- a/backend/src/main/java/proj/pet/comment/domain/Comment.java
+++ b/backend/src/main/java/proj/pet/comment/domain/Comment.java
@@ -6,19 +6,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
-
-import static jakarta.persistence.GenerationType.AUTO;
 
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 @Getter
-public class Comment {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Comment extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "board_id", nullable = false, updatable = false)
@@ -33,4 +30,22 @@ public class Comment {
 
 	@Column(name = "deleted_at")
 	private LocalDateTime deletedAt;
+
+	protected Comment(Board board, Member member, LocalDateTime createdAt) {
+		this.board = board;
+		this.member = member;
+		this.createdAt = createdAt;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Comment of(Board board, Member member, LocalDateTime createdAt) {
+		return new Comment(board, member, createdAt);
+	}
+	@Override public boolean isValid() {
+		return board != null
+				&& !board.isNew()
+				&& member != null
+				&& !member.isNew()
+				&& createdAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/exception/ExceptionStatus.java
+++ b/backend/src/main/java/proj/pet/exception/ExceptionStatus.java
@@ -22,6 +22,7 @@ public enum ExceptionStatus {
 	UNAUTHENTICATED(HttpStatus.FORBIDDEN, "권한이 없는 요청입니다."),
 
 	/*-----------------------------------DOMAIN-----------------------------------*/
+	INVARIANT_VIOLENCE(HttpStatus.BAD_REQUEST, "불변식에 위배되는 생성 매개변수입니다."),
 	INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "유효하지 않은 입력입니다."),
 	;
 

--- a/backend/src/main/java/proj/pet/follow/domain/Follow.java
+++ b/backend/src/main/java/proj/pet/follow/domain/Follow.java
@@ -5,6 +5,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.member.domain.Member;
 import proj.pet.utils.domain.MemberCompositeKey;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
@@ -14,7 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Table(name = "FOLLOW")
 @Getter
-public class Follow {
+public class Follow implements Validatable {
 
 	@EmbeddedId
 	private MemberCompositeKey id;
@@ -29,4 +31,25 @@ public class Follow {
 
 	@Column(name = "followed_at", nullable = false)
 	private LocalDateTime followedAt;
+
+	private Follow(Member from, Member to, LocalDateTime now) {
+		this.id = MemberCompositeKey.of(from.getId(), to.getId());
+		this.from = from;
+		this.to = to;
+		this.followedAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Follow of(Member from, Member to, LocalDateTime now) {
+		return new Follow(from, to, now);
+	}
+
+	@Override public boolean isValid() {
+		return id.isValid()
+				&& from != null
+				&& !from.isNew()
+				&& to != null
+				&& !to.isNew()
+				&& followedAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/member/domain/Member.java
+++ b/backend/src/main/java/proj/pet/member/domain/Member.java
@@ -1,7 +1,6 @@
 package proj.pet.member.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.block.domain.Block;
@@ -70,8 +69,7 @@ public class Member extends IdDomain implements Validatable {
 	private List<Follow> followers = new ArrayList<>();
 
 
-	@Builder
-	public Member(OauthProfile oauthProfile, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
+	private Member(OauthProfile oauthProfile, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
 		this.oauthProfile = oauthProfile;
 		this.profileImageUrl = profileImageUrl;
 		this.country = country;
@@ -81,6 +79,10 @@ public class Member extends IdDomain implements Validatable {
 		this.nicknameUpdatedAt = now;
 		this.createdAt = now;
 		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Member of(OauthProfile oauthProfile, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
+		return new Member(oauthProfile, profileImageUrl, country, nickname, statement, memberRole, now);
 	}
 
 	@Override public boolean isValid() {

--- a/backend/src/main/java/proj/pet/member/domain/Member.java
+++ b/backend/src/main/java/proj/pet/member/domain/Member.java
@@ -1,28 +1,26 @@
 package proj.pet.member.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.block.domain.Block;
 import proj.pet.follow.domain.Follow;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Table(name = "MEMBER")
 @Getter
-public class Member {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Member extends IdDomain implements Validatable {
 
 	@Column(name = "oauth_type", nullable = false)
 	private OauthType oauthType;
@@ -43,6 +41,7 @@ public class Member {
 	private String statement;
 
 	@Column(name = "role", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private MemberRole memberRole;
 
 	@Column(name = "nickname_updated_at", nullable = false)
@@ -71,4 +70,28 @@ public class Member {
 			cascade = CascadeType.ALL,
 			orphanRemoval = true)
 	private List<Follow> followers = new ArrayList<>();
+
+
+	@Builder
+	public Member(OauthType oauthType, String oauthId, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
+		this.oauthType = oauthType;
+		this.oauthId = oauthId;
+		this.profileImageUrl = profileImageUrl;
+		this.country = country;
+		this.nickname = nickname;
+		this.statement = statement;
+		this.memberRole = memberRole;
+		this.nicknameUpdatedAt = now;
+		this.createdAt = now;
+	}
+
+	@Override public boolean isValid() {
+		return oauthType != null
+				&& oauthId != null
+				&& country != null
+				&& nickname != null
+				&& memberRole != null
+				&& nicknameUpdatedAt != null
+				&& createdAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/member/domain/Member.java
+++ b/backend/src/main/java/proj/pet/member/domain/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import proj.pet.block.domain.Block;
 import proj.pet.follow.domain.Follow;
 import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
 import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
@@ -22,20 +23,20 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 public class Member extends IdDomain implements Validatable {
 
-	@Column(name = "oauth_type", nullable = false)
-	private OauthType oauthType;
-
-	@Column(name = "oauth_id", nullable = false)
-	private String oauthId;
-
-	@Column(name = "profile_image_url")
-	private String profileImageUrl;
+	@Embedded
+	private OauthProfile oauthProfile;
 
 	@Column(name = "country", nullable = false)
 	private Country country;
 
+	@Column(name = "profile_image_url")
+	private String profileImageUrl;
+
 	@Column(name = "nickname", nullable = false, length = 12)
 	private String nickname;
+
+	@Column(name = "nickname_updated_at", nullable = false)
+	private LocalDateTime nicknameUpdatedAt;
 
 	@Column(name = "statement", length = 30)
 	private String statement;
@@ -43,9 +44,6 @@ public class Member extends IdDomain implements Validatable {
 	@Column(name = "role", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private MemberRole memberRole;
-
-	@Column(name = "nickname_updated_at", nullable = false)
-	private LocalDateTime nicknameUpdatedAt;
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
@@ -73,9 +71,8 @@ public class Member extends IdDomain implements Validatable {
 
 
 	@Builder
-	public Member(OauthType oauthType, String oauthId, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
-		this.oauthType = oauthType;
-		this.oauthId = oauthId;
+	public Member(OauthProfile oauthProfile, String profileImageUrl, Country country, String nickname, String statement, MemberRole memberRole, LocalDateTime now) {
+		this.oauthProfile = oauthProfile;
 		this.profileImageUrl = profileImageUrl;
 		this.country = country;
 		this.nickname = nickname;
@@ -83,11 +80,11 @@ public class Member extends IdDomain implements Validatable {
 		this.memberRole = memberRole;
 		this.nicknameUpdatedAt = now;
 		this.createdAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
 	}
 
 	@Override public boolean isValid() {
-		return oauthType != null
-				&& oauthId != null
+		return oauthProfile != null
 				&& country != null
 				&& nickname != null
 				&& memberRole != null

--- a/backend/src/main/java/proj/pet/member/domain/OauthProfile.java
+++ b/backend/src/main/java/proj/pet/member/domain/OauthProfile.java
@@ -1,0 +1,43 @@
+package proj.pet.member.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class OauthProfile implements Validatable {
+
+	@Column(name = "oauth_type", nullable = false)
+	@Enumerated(EnumType.STRING)
+	private OauthType type;
+
+	@Column(name = "oauth_id", nullable = false)
+	private String id;
+
+	@Column(name = "oauth_name")
+	private String name;
+
+	private OauthProfile(OauthType type, String id, String name) {
+		this.type = type;
+		this.id = id;
+		this.name = name;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static OauthProfile of(OauthType type, String id, String oauthName) {
+		return new OauthProfile(type, id, oauthName);
+	}
+
+	@Override public boolean isValid() {
+		return type != null
+				&& id != null;
+	}
+}

--- a/backend/src/main/java/proj/pet/member/domain/OauthType.java
+++ b/backend/src/main/java/proj/pet/member/domain/OauthType.java
@@ -1,7 +1,7 @@
 package proj.pet.member.domain;
 
 public enum OauthType {
-	FT,
+	FORTY_TWO,
 	GOOGLE,
 
 }

--- a/backend/src/main/java/proj/pet/reaction/domain/Reaction.java
+++ b/backend/src/main/java/proj/pet/reaction/domain/Reaction.java
@@ -5,21 +5,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Getter
-public class Reaction {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Reaction extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "board_id", nullable = false, updatable = false)
@@ -30,8 +28,30 @@ public class Reaction {
 	private Member member;
 
 	@Column(name = "reaction_type", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private ReactionType reactionType;
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
+
+	protected Reaction(Board board, Member member, ReactionType reactionType, LocalDateTime now) {
+		this.board = board;
+		this.member = member;
+		this.reactionType = reactionType;
+		this.createdAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Reaction of(Board board, Member member, ReactionType reactionType, LocalDateTime now) {
+		return new Reaction(board, member, reactionType, now);
+	}
+
+	@Override public boolean isValid() {
+		return board != null
+				&& !board.isNew()
+				&& member != null
+				&& !member.isNew()
+				&& reactionType != null
+				&& createdAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/report/domain/Report.java
+++ b/backend/src/main/java/proj/pet/report/domain/Report.java
@@ -1,7 +1,6 @@
 package proj.pet.report.domain;
 
 import jakarta.persistence.*;
-import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
@@ -47,8 +46,7 @@ public class Report extends IdDomain implements Validatable {
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
 
-	@Builder
-	public Report(Member from, Member to, Board board, Comment comment, ReportReason reason, String content, LocalDateTime now) {
+	private Report(Member from, Member to, Board board, Comment comment, ReportReason reason, String content, LocalDateTime now) {
 		this.from = from;
 		this.to = to;
 		this.board = board;
@@ -59,15 +57,15 @@ public class Report extends IdDomain implements Validatable {
 		RuntimeExceptionThrower.checkValidity(this);
 	}
 
+	public static Report of(Member from, Member to, Board board, Comment comment, ReportReason reason, String content, LocalDateTime now) {
+		return new Report(from, to, board, comment, reason, content, now);
+	}
+
 	@Override public boolean isValid() {
-		return from != null
-				&& !from.isNew()
-				&& to != null
-				&& !to.isNew()
-				&& board != null
-				&& !board.isNew()
-				&& comment != null
-				&& !comment.isNew()
+		return from != null && !from.isNew()
+				&& to != null && !to.isNew()
+				&& board != null && !board.isNew()
+				&& comment != null && !comment.isNew()
 				&& reason != null
 				&& createdAt != null;
 	}

--- a/backend/src/main/java/proj/pet/report/domain/Report.java
+++ b/backend/src/main/java/proj/pet/report/domain/Report.java
@@ -1,26 +1,25 @@
 package proj.pet.report.domain;
 
 import jakarta.persistence.*;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.comment.domain.Comment;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @NoArgsConstructor(access = PROTECTED)
 @Entity
 @Getter
-public class Report {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Report extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = LAZY)
 	@JoinColumn(name = "member_id", nullable = false, updatable = false)
@@ -39,6 +38,7 @@ public class Report {
 	private Comment comment;
 
 	@Column(name = "reason", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private ReportReason reason;
 
 	@Column(name = "content", length = 255)
@@ -46,4 +46,29 @@ public class Report {
 
 	@Column(name = "created_at", nullable = false)
 	private LocalDateTime createdAt;
+
+	@Builder
+	public Report(Member from, Member to, Board board, Comment comment, ReportReason reason, String content, LocalDateTime now) {
+		this.from = from;
+		this.to = to;
+		this.board = board;
+		this.comment = comment;
+		this.reason = reason;
+		this.content = content;
+		this.createdAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	@Override public boolean isValid() {
+		return from != null
+				&& !from.isNew()
+				&& to != null
+				&& !to.isNew()
+				&& board != null
+				&& !board.isNew()
+				&& comment != null
+				&& !comment.isNew()
+				&& reason != null
+				&& createdAt != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
+++ b/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
@@ -5,21 +5,19 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import proj.pet.board.domain.Board;
 import proj.pet.member.domain.Member;
+import proj.pet.utils.domain.IdDomain;
+import proj.pet.utils.domain.RuntimeExceptionThrower;
+import proj.pet.utils.domain.Validatable;
 
 import java.time.LocalDateTime;
 
-import static jakarta.persistence.GenerationType.AUTO;
 import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Table(name = "scrap")
 @NoArgsConstructor(access = PROTECTED)
 @Getter
-public class Scrap {
-
-	@Id
-	@GeneratedValue(strategy = AUTO)
-	private Long id;
+public class Scrap extends IdDomain implements Validatable {
 
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "member_id", nullable = false, updatable = false)
@@ -31,4 +29,19 @@ public class Scrap {
 
 	@Column(name = "created_at", nullable = false, updatable = false)
 	private LocalDateTime createdAt;
+
+	private Scrap(Member member, Board board, LocalDateTime now) {
+		this.member = member;
+		this.board = board;
+		this.createdAt = now;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static Scrap of(Member member, Board board, LocalDateTime now) {
+		return new Scrap(member, board, now);
+	}
+
+	@Override public boolean isValid() {
+		return false;
+	}
 }

--- a/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
+++ b/backend/src/main/java/proj/pet/scrap/domain/Scrap.java
@@ -42,6 +42,10 @@ public class Scrap extends IdDomain implements Validatable {
 	}
 
 	@Override public boolean isValid() {
-		return false;
+		return member != null
+				&& !member.isNew()
+				&& board != null
+				&& !board.isNew()
+				&& createdAt != null;
 	}
 }

--- a/backend/src/main/java/proj/pet/utils/domain/ConsumptionCompositeKey.java
+++ b/backend/src/main/java/proj/pet/utils/domain/ConsumptionCompositeKey.java
@@ -1,13 +1,31 @@
 package proj.pet.utils.domain;
 
 import jakarta.persistence.Embeddable;
+import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
 
 @Embeddable
-public class ConsumptionCompositeKey implements Serializable {
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class ConsumptionCompositeKey implements Serializable, Validatable {
 
 	private Long consumerId;
 
 	private Long providerId;
+
+
+	private ConsumptionCompositeKey(Long consumerId, Long providerId) {
+		this.consumerId = consumerId;
+		this.providerId = providerId;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static ConsumptionCompositeKey of(Long consumerId, Long providerId) {
+		return new ConsumptionCompositeKey(consumerId, providerId);
+	}
+
+	@Override public boolean isValid() {
+		return consumerId != null
+				&& providerId != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/utils/domain/IdDomain.java
+++ b/backend/src/main/java/proj/pet/utils/domain/IdDomain.java
@@ -1,0 +1,56 @@
+package proj.pet.utils.domain;
+
+import jakarta.persistence.*;
+import org.springframework.data.domain.Persistable;
+
+/**
+ * Long인 단일 Id를 가지는 엔티티의 추상 클래스입니다.
+ * <p>
+ *     {@link Persistable} 인터페이스를 구현하여, {@link #isNew()} 메서드를 구현합니다.
+ *     <br>
+ *     {@link #isNew()} 메서드는 {@link #id}가 null인지 여부를 반환합니다.
+ *     <br>
+ *     {@link #id}가 null이면 새로운 엔티티로 판단합니다.
+ *     <br>
+ *     {@link #equals(Object)}와 {@link #hashCode()} 메서드를 구현합니다.
+ */
+@MappedSuperclass
+public abstract class IdDomain implements Persistable<Long> {
+
+	@Id @Column(name = "id")
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id = null;
+	@Transient
+	private boolean isNew = true;
+
+	@Override
+	public Long getId() {
+		return id;
+	};
+
+	/**
+	 * Long 타입 Id를 갖는 엔티티의 경우, Equals와 HashCode는 고정이므로, final로 선언합니다.
+	 */
+	@Override
+	public final boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || !getClass().equals(o.getClass())) return false;
+		return getId() != null && getId().equals(((IdDomain) o).getId());
+	}
+
+	@Override
+	public final int hashCode() {
+		return getId() == null ? 0 : getId().hashCode();
+	}
+
+	@Override
+	public boolean isNew() {
+		return this.isNew;
+	}
+
+	@PostLoad
+	@PostPersist
+	protected void markNotNew() {
+		this.isNew = false;
+	}
+}

--- a/backend/src/main/java/proj/pet/utils/domain/MemberCompositeKey.java
+++ b/backend/src/main/java/proj/pet/utils/domain/MemberCompositeKey.java
@@ -2,16 +2,34 @@ package proj.pet.utils.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
-import java.io.Serializable;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
 
 @Embeddable
 @Getter
-public class MemberCompositeKey implements Serializable {
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+public class MemberCompositeKey implements Serializable, Validatable {
 
 	@Column(name = "member_id")
 	private Long memberId;
 
 	@Column(name = "target_member_id")
 	private Long targetMemberId;
+
+	private MemberCompositeKey(Long memberId, Long targetMemberId) {
+		this.memberId = memberId;
+		this.targetMemberId = targetMemberId;
+		RuntimeExceptionThrower.checkValidity(this);
+	}
+
+	public static MemberCompositeKey of(Long memberId, Long targetMemberId) {
+		return new MemberCompositeKey(memberId, targetMemberId);
+	}
+
+	@Override public boolean isValid() {
+		return memberId != null
+				&& targetMemberId != null;
+	}
 }

--- a/backend/src/main/java/proj/pet/utils/domain/RuntimeExceptionThrower.java
+++ b/backend/src/main/java/proj/pet/utils/domain/RuntimeExceptionThrower.java
@@ -18,6 +18,6 @@ public class RuntimeExceptionThrower {
 
 	public static void checkValidity(Validatable validatable) {
 		if (!validatable.isValid())
-			throw new DomainException(ExceptionStatus.INVALID_ARGUMENT);
+			throw new DomainException(ExceptionStatus.INVARIANT_VIOLENCE);
 	}
 }


### PR DESCRIPTION
…각 엔티티 불변식, 생성자 추가

<!-- PULL REQUEST TEMPLATE -->
<!-- (체크박스 "[ ]"를 "[x]"로 작성하여, 체크해주세요) -->

## 해당 사항 (중복 선택)

- [x] FEAT : 새로운 기능 추가 및 개선
- [ ] FIX : 기존 기능 수정 및 정상 동작을 위한 간단한 추가, 수정사항
- [ ] BUG : 버그 수정
- [ ] REFACTOR : 결과의 변경 없이 코드의 구조를 재조정
- [ ] TEST : 테스트 코드 추가
- [ ] DOCS : 코드가 아닌 문서를 수정한 경우
- [ ] REMOVE : 파일을 삭제하는 작업만 수행
- [ ] RENAME : 파일 또는 폴더명을 수정하거나 위치(경로)를 변경
- [ ] ETC : 이외에 다른 경우 - 어떠한 사항인지 작성해주세요.

## 설명
>아래 링크에 이슈번호를 적어주세요. 예) .../42pet/issues/123

https://github.com/42pet/42pet/issues/

- Long 타입 Id를 갖는 도메인 객체에 대한 공통 관심사를 구현한 IdDomain 추상 클래스 구현
- 도메인 엔티티에 IdDomain을 상속하도록 설정, CompositeKey를 사용하는 경우에는 pass
- Validatable 인터페이스 구현을 하도록 설정, isValid 불변식 구현
- 해당 불변식 기준 변수가 적당한 경우에는 of 생성자, 이외에 좀 많은 경우에는 Builder를 사용하도록 구현